### PR TITLE
Use new name for wasm32-wasi: wasm32-wasip1

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,5 @@
 # These command aliases are not final, may change
 [alias]
 # Alias to build actual plugin binary for the specified target.
-build-wasi = "build --target wasm32-wasi"
+build-wasi = "build --target wasm32-wasip1"
 build-wasm32 = "build --target wasm32-unknown-unknown"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env.TOOLCHAIN }}
-          targets: wasm32-wasi
+          targets: wasm32-wasip1
           components: rustfmt
 
       - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env.TOOLCHAIN }}
-          targets: wasm32-wasi
+          targets: wasm32-wasip1
 
       - name: Set up Node
         uses: actions/setup-node@v4

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ You can follow instructions at ['Install Rust' page from the official rust websi
 ## Add wasm target to rust
 
 ```bash
-rustup target add wasm32-wasi
+rustup target add wasm32-wasip1
 ```
 
 ## Running tests
@@ -23,10 +23,10 @@ cargo test jsx_
 ## Building for production
 
 ```bash
-# (alias for `cargo build --target wasm32-wasi`)
+# (alias for `cargo build --target wasm32-wasip1`)
 cargo build-wasi --release
 ```
-Then wasm binary would be on the path: `./target/wasm32-wasi/release/lingui_macro_plugin.wasm`
+Then wasm binary would be on the path: `./target/wasm32-wasip1/release/lingui_macro_plugin.wasm`
 
 You can check it in your own project or in the `examples/nextjs-13` example in this repo by specifying full path to the WASM binary:
 
@@ -35,7 +35,7 @@ You can check it in your own project or in the `examples/nextjs-13` example in t
 const nextConfig = {
   experimental: {
     swcPlugins: [
-      ['/Users/tim/projects/lingui-macro-plugin/target/wasm32-wasi/release/lingui_macro_plugin.wasm', {}],
+      ['/Users/tim/projects/lingui-macro-plugin/target/wasm32-wasip1/release/lingui_macro_plugin.wasm', {}],
     ],
   },
 };

--- a/examples/nextjs/next.config.js
+++ b/examples/nextjs/next.config.js
@@ -1,7 +1,7 @@
 const path = require('node:path');
 
 const plugin = process.env.USE_LOCAL_PLUGIN_BINARY
-    ? path.join(__dirname, '../../target/wasm32-wasi/release/lingui_macro_plugin.wasm')
+    ? path.join(__dirname, '../../target/wasm32-wasip1/release/lingui_macro_plugin.wasm')
     : '@lingui/swc-plugin';
 
 

--- a/package.json
+++ b/package.json
@@ -20,9 +20,9 @@
     "i18n",
     "internalization"
   ],
-  "main": "target/wasm32-wasi/release/lingui_macro_plugin.wasm",
+  "main": "target/wasm32-wasip1/release/lingui_macro_plugin.wasm",
   "exports": {
-    ".": "./target/wasm32-wasi/release/lingui_macro_plugin.wasm"
+    ".": "./target/wasm32-wasip1/release/lingui_macro_plugin.wasm"
   },
   "scripts": {
     "prepublishOnly": "cargo build-wasi --release"


### PR DESCRIPTION
## Summary:

The target name for wasm32-wasi was renamed to `wasm32-wasip1` (see https://doc.rust-lang.org/rustc/platform-support/wasm32-wasip1.html)

This PR adjusts the tooling to use this new name